### PR TITLE
Update message handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ custom.toml
 custom_*.toml
 outputs/
 *.db
+
+# VS Code
+.vscode/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,10 +9,12 @@ All notable changes to this project are documented here.
 - Skipped message persistence to `outputs/skipped/` with reason metadata (`__infos__`).
 - STAC preflight health check (configurable via `consumer.preflight_stac`).
 - External failures counter in stats and SQLite reporter.
+ - Abstract `RecorderBase` for persistence recorders to unify common behavior.
 
 ### Changed
 - Missing payload/item and invalid JSON Patch now treated as errors (count toward `max_errors`).
 - Retry command supports processing skipped JSONL files alongside failures.
+ - Replaced legacy persistence methods (`record_item`, `record_skipped_item`, `record_failed_item`) with a unified `record(key, data, reason=None, retries=None)` API across `DumpRecorder`, `SkipRecorder`, and `FailureRecovery`.
 
 ## [2.0.0] - 2026-01-13
 - Initial project setup.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project are documented here.
 
+## [Unreleased]
+### Added
+- Transient external failure policy with bounded retries and exponential backoff for STAC fetch.
+- `--force` option to continue consumption despite transient external failures (records skipped items).
+- Skipped message persistence to `outputs/skipped/` with reason metadata (`__infos__`).
+- STAC preflight health check (configurable via `consumer.preflight_stac`).
+- External failures counter in stats and SQLite reporter.
+
+### Changed
+- Missing payload/item and invalid JSON Patch now treated as errors (count toward `max_errors`).
+- Retry command supports processing skipped JSONL files alongside failures.
+
 ## [2.0.0] - 2026-01-13
 - Initial project setup.
 - Add bump-my-version configuration and Makefile targets for patch/minor/major bumps.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented here.
 - Missing payload/item and invalid JSON Patch now treated as errors (count toward `max_errors`).
 - Retry command supports processing skipped JSONL files alongside failures.
  - Replaced legacy persistence methods (`record_item`, `record_skipped_item`, `record_failed_item`) with a unified `record(key, data, reason=None, retries=None)` API across `DumpRecorder`, `SkipRecorder`, and `FailureRecovery`.
+ - Simplified persistence: unified instance `record()` on `RecorderBase` with standardized logging; extracted JSONL helpers to `piddiplatsch.persist.helpers`.
 
 ## [2.0.0] - 2026-01-13
 - Initial project setup.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ Interested in contributing? Check out our [CONTRIBUTING.md](CONTRIBUTING.md) for
 
 Failed items are saved to `outputs/failures/r<N>/failed_items_<date>.jsonl` for later retry.
 
+### Dumped Messages
+
+When running the consumer with `--dump`, all consumed messages are appended to
+`outputs/dump/dump_messages_<date>.jsonl` (one JSON object per line). This is useful for
+debugging, audits, or crafting reproducible tests. Dump files contain raw messages and
+do not include the failure metadata (`__infos__`) used by the retry workflow.
+
+Example run with dump enabled:
+
+```bash
+piddiplatsch --config custom.toml --verbose consume --dump
+```
+
 ### Skipped Messages (Transient External Failures)
 
 Transient external failures (e.g., STAC unreachable, timeouts, HTTP 5xx) are recorded under `outputs/skipped/skipped_items_<date>.jsonl` when running with `--force`. By default (production), the consumer stops on such failures after bounded retries.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,22 @@ Interested in contributing? Check out our [CONTRIBUTING.md](CONTRIBUTING.md) for
 
 Failed items are saved to `outputs/failures/r<N>/failed_items_<date>.jsonl` for later retry.
 
+### Persistence API (Short)
+
+Recorders share a unified instance API via `RecorderBase`:
+
+```python
+from piddiplatsch.persist.dump import DumpRecorder
+from piddiplatsch.persist.skipped import SkipRecorder
+from piddiplatsch.persist.recovery import FailureRecovery
+
+DumpRecorder().record(key, data)
+SkipRecorder().record(key, data, reason="timeout", retries=1)
+FailureRecovery().record(key, data, reason="error", retries=2)
+```
+
+Helpers for JSONL I/O and daily rotation live in `piddiplatsch.persist.helpers` (`DailyJsonlWriter`, `read_jsonl`, `find_jsonl`).
+
 ### Dumped Messages
 
 When running the consumer with `--dump`, all consumed messages are appended to

--- a/src/piddiplatsch/cli.py
+++ b/src/piddiplatsch/cli.py
@@ -47,8 +47,13 @@ def cli(ctx, config_file, debug, verbose, log):
     is_flag=True,
     help="Do not publish to handle server; write handles to JSONL only.",
 )
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Continue on transient external failures (e.g., STAC down).",
+)
 @click.pass_context
-def consume(ctx, dump, dry_run):
+def consume(ctx, dump, dry_run, force):
     """Start the Kafka consumer."""
     topic = config.get("consumer", "topic")
     kafka_cfg = config.get("kafka")
@@ -60,6 +65,7 @@ def consume(ctx, dump, dry_run):
         dump_messages=dump,
         verbose=ctx.obj["verbose"],
         dry_run=dry_run,
+        force=force,
     )
 
 

--- a/src/piddiplatsch/config/default.toml
+++ b/src/piddiplatsch/config/default.toml
@@ -3,6 +3,20 @@ processor = "cmip6"
 topic = "CMIP6"
 output_dir = "outputs"
 max_errors = 10  # -1 = unlimited, any positive int = stop after that many
+ # --- Transient External Failure Handling (STAC/network) ---
+ # stop_on_transient_skip: if true, stop consumption on transient external failures
+ #   (e.g., STAC unreachable/timeouts/HTTP 5xx) after bounded retries.
+ #   Override at runtime with the CLI flag --force to continue.
+ stop_on_transient_skip = true
+ # transient_retries: number of attempts for transient fetch failures (PATCH fetch).
+ transient_retries = 3
+ # transient_backoff_initial: initial backoff delay in seconds for retries.
+ transient_backoff_initial = 0.5
+ # transient_backoff_max: maximum backoff delay in seconds.
+ transient_backoff_max = 5.0
+ # preflight_stac: probe STAC health at startup; if unhealthy and not forced,
+ #   the consumer exits early (fail-fast).
+ preflight_stac = true
 
 [kafka]
 "bootstrap.servers" = "localhost:39092"

--- a/src/piddiplatsch/consumer.py
+++ b/src/piddiplatsch/consumer.py
@@ -15,8 +15,8 @@ from piddiplatsch.persist.dump import DumpRecorder
 from piddiplatsch.persist.recovery import FailureRecovery
 from piddiplatsch.persist.skipped import SkipRecorder
 from piddiplatsch.processing import FeedResult, ProcessingResult
-from piddiplatsch.processing.registry import get_processor
 from piddiplatsch.processing.base import BaseProcessor
+from piddiplatsch.processing.registry import get_processor
 
 logger = logging.getLogger(__name__)
 
@@ -165,9 +165,7 @@ class ConsumerPipeline:
                         key, value, reason=result.skip_reason
                     )
                 except Exception:
-                    logger.exception(
-                        f"Failed to persist skipped message {key}"
-                    )
+                    logger.exception(f"Failed to persist skipped message {key}")
 
                 if result.transient_skip:
                     self._consecutive_transient_skips += 1

--- a/src/piddiplatsch/consumer.py
+++ b/src/piddiplatsch/consumer.py
@@ -161,7 +161,7 @@ class ConsumerPipeline:
             if result.skipped:
                 self.stats.skip(message=f"message={key}")
                 try:
-                    SkipRecorder.record(key, value, reason=result.skip_reason)
+                    SkipRecorder().record(key, value, reason=result.skip_reason)
                 except Exception:
                     logger.exception(f"Failed to persist skipped message {key}")
 
@@ -193,13 +193,13 @@ class ConsumerPipeline:
         try:
             logger.debug(f"Processing message: {key}")
             if self.dump_messages:
-                DumpRecorder.record(key, value)
+                DumpRecorder().record(key, value)
             return self.processor.process(key, value)
         except Exception as e:
             logger.exception(f"Error processing message {key}")
             retries = value.get("retries", 0)
             reason = str(e)
-            FailureRecovery.record(key, value, retries=retries, reason=reason)
+            FailureRecovery().record(key, value, retries=retries, reason=reason)
             return ProcessingResult(key=key, success=False, error=reason)
 
     def stop(self, cause: StopCause = StopCause.MANUAL):

--- a/src/piddiplatsch/consumer.py
+++ b/src/piddiplatsch/consumer.py
@@ -161,9 +161,7 @@ class ConsumerPipeline:
             if result.skipped:
                 self.stats.skip(message=f"message={key}")
                 try:
-                    SkipRecorder.record_skipped_item(
-                        key, value, reason=result.skip_reason
-                    )
+                    SkipRecorder.record(key, value, reason=result.skip_reason)
                 except Exception:
                     logger.exception(f"Failed to persist skipped message {key}")
 
@@ -195,15 +193,13 @@ class ConsumerPipeline:
         try:
             logger.debug(f"Processing message: {key}")
             if self.dump_messages:
-                DumpRecorder.record_item(key, value)
+                DumpRecorder.record(key, value)
             return self.processor.process(key, value)
         except Exception as e:
             logger.exception(f"Error processing message {key}")
             retries = value.get("retries", 0)
             reason = str(e)
-            FailureRecovery.record_failed_item(
-                key, value, retries=retries, reason=reason
-            )
+            FailureRecovery.record(key, value, retries=retries, reason=reason)
             return ProcessingResult(key=key, success=False, error=reason)
 
     def stop(self, cause: StopCause = StopCause.MANUAL):

--- a/src/piddiplatsch/exceptions.py
+++ b/src/piddiplatsch/exceptions.py
@@ -15,3 +15,11 @@ class ValidationError(PiddiplatschError):
 
 class MaxErrorsExceededError(PiddiplatschError):
     """Raised when the consumer reaches its max error limit."""
+
+
+class TransientExternalError(PiddiplatschError):
+    """Raised when an external dependency (e.g., STAC) fails transiently after retries."""
+
+
+class StopOnTransientSkipError(PiddiplatschError):
+    """Raised by the pipeline to stop consumption due to transient external failures when policy dictates fail-fast."""

--- a/src/piddiplatsch/monitoring/stats.py
+++ b/src/piddiplatsch/monitoring/stats.py
@@ -38,6 +38,7 @@ class CounterKey(StrEnum):
     SKIPPED = "skipped_messages"
     PATCHED = "patched_messages"
     HANDLE_TIME = "total_handle_processing_time"  # float seconds
+    EXTERNAL_FAILS = "external_failures"
 
 
 # -----------------------
@@ -73,6 +74,7 @@ class SQLiteReporter(StatsReporter):
                 warnings INTEGER,
                 skipped_messages INTEGER,
                 patched_messages INTEGER,
+                external_failures INTEGER,
                 total_handle_processing_time REAL,
                 uptime REAL,
                 message_rate REAL,
@@ -96,9 +98,9 @@ class SQLiteReporter(StatsReporter):
             """
             INSERT INTO message_stats (ts, messages, errors, retries, handles,
                                        retracted_messages, replicas, warnings,
-                                       skipped_messages, patched_messages, total_handle_processing_time,
+                                       skipped_messages, patched_messages, external_failures, total_handle_processing_time,
                                        uptime, message_rate, handle_rate, messages_per_sec)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 ts,
@@ -111,6 +113,7 @@ class SQLiteReporter(StatsReporter):
                 summary[CounterKey.WARNINGS.value],
                 summary[CounterKey.SKIPPED.value],
                 summary[CounterKey.PATCHED.value],
+                summary[CounterKey.EXTERNAL_FAILS.value],
                 summary[CounterKey.HANDLE_TIME.value],
                 summary["uptime"],
                 summary["message_rate"],
@@ -260,6 +263,11 @@ class Stats:
         self.increment(CounterKey.PATCHED, n)
         if message:
             logger.info(f"PATCHED: {message}")
+
+    def external_fail(self, message: str | None = None, n=1):
+        self.increment(CounterKey.EXTERNAL_FAILS, n)
+        if message:
+            logger.warning(f"EXTERNAL-FAIL: {message}")
 
     # --- Logging / persistence ---
     def _maybe_log(self):

--- a/src/piddiplatsch/monitoring/stats.py
+++ b/src/piddiplatsch/monitoring/stats.py
@@ -62,8 +62,7 @@ class SQLiteReporter(StatsReporter):
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._cursor = self._conn.cursor()
         # Store timestamps as TEXT (ISO 8601 UTC strings)
-        self._cursor.execute(
-            """
+        self._cursor.execute("""
             CREATE TABLE IF NOT EXISTS message_stats (
                 ts TEXT PRIMARY KEY,
                 messages INTEGER,
@@ -82,8 +81,7 @@ class SQLiteReporter(StatsReporter):
                 handle_rate REAL,
                 messages_per_sec REAL
             )
-            """
-        )
+            """)
         self._cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_message_stats_ts ON message_stats(ts)"
         )

--- a/src/piddiplatsch/monitoring/stats.py
+++ b/src/piddiplatsch/monitoring/stats.py
@@ -62,7 +62,8 @@ class SQLiteReporter(StatsReporter):
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._cursor = self._conn.cursor()
         # Store timestamps as TEXT (ISO 8601 UTC strings)
-        self._cursor.execute("""
+        self._cursor.execute(
+            """
             CREATE TABLE IF NOT EXISTS message_stats (
                 ts TEXT PRIMARY KEY,
                 messages INTEGER,
@@ -81,7 +82,8 @@ class SQLiteReporter(StatsReporter):
                 handle_rate REAL,
                 messages_per_sec REAL
             )
-            """)
+            """
+        )
         self._cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_message_stats_ts ON message_stats(ts)"
         )

--- a/src/piddiplatsch/persist/base.py
+++ b/src/piddiplatsch/persist/base.py
@@ -1,4 +1,5 @@
 import json
+from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -51,6 +52,50 @@ class JsonlRecorder:
         self, data: dict, infos: dict | None = None, subdir: Path | None = None
     ) -> Path:
         payload = DailyJsonlWriter.wrap_with_infos(data, infos) if infos else data
+        return self.writer.write(self.prefix, payload, subdir=subdir)
+
+
+class RecorderBase(ABC):
+    """Abstract base for high-level category recorders.
+
+    Subclasses provide how to prepare the payload/infos/subdir while this class
+    implements the common write orchestration to a daily JSONL using
+    `DailyJsonlWriter`.
+
+    Implement `prepare()` to shape the record and optional subdirectory.
+    """
+
+    def __init__(self, root_dir: Path, prefix: str):
+        self.root_dir = Path(root_dir)
+        self.prefix = prefix
+        self.writer = DailyJsonlWriter(self.root_dir)
+
+    @abstractmethod
+    def prepare(
+        self,
+        key: str,
+        data: dict,
+        reason: str | None,
+        retries: int | None,
+    ) -> tuple[dict, dict | None, Path | None]:
+        """Return a tuple of (payload, infos, subdir).
+
+        - `payload`: dict to be written (before infos wrapping)
+        - `infos`: optional metadata dict to be wrapped under `__infos__`
+        - `subdir`: optional absolute directory where the daily file should be written
+        """
+
+    def write(
+        self,
+        key: str,
+        data: dict,
+        *,
+        reason: str | None = None,
+        retries: int | None = None,
+    ) -> Path:
+        payload, infos, subdir = self.prepare(key, data, reason, retries)
+        if infos:
+            payload = DailyJsonlWriter.wrap_with_infos(payload, infos)
         return self.writer.write(self.prefix, payload, subdir=subdir)
 
 

--- a/src/piddiplatsch/persist/base.py
+++ b/src/piddiplatsch/persist/base.py
@@ -1,59 +1,8 @@
-import json
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
-from datetime import UTC, datetime
 from pathlib import Path
 
-
-class DailyJsonlWriter:
-    """Utility for writing JSONL records to daily-rotated files.
-
-    - Uses a directory (root) and a filename prefix (e.g., 'skipped_items').
-    - Appends one JSON object per line.
-    - Returns the path of the written file.
-    """
-
-    def __init__(self, root_dir: Path):
-        self.root_dir = Path(root_dir)
-        self.root_dir.mkdir(parents=True, exist_ok=True)
-
-    @staticmethod
-    def wrap_with_infos(data: dict, infos: dict) -> dict:
-        # Merge metadata under `__infos__` key
-        wrapped = {**data, "__infos__": infos}
-        return wrapped
-
-    def write(self, prefix: str, data: dict, subdir: Path | None = None) -> Path:
-        now = datetime.now(UTC)
-        dated_filename = f"{prefix}_{now.date()}.jsonl"
-        target_dir = Path(subdir) if subdir else self.root_dir
-        target_dir.mkdir(parents=True, exist_ok=True)
-        target_path = target_dir / dated_filename
-        with target_path.open("a", encoding="utf-8") as f:
-            json.dump(data, f)
-            f.write("\n")
-        return target_path
-
-
-class JsonlRecorder:
-    """High-level recorder for appending JSON objects to daily JSONL files.
-
-    Example:
-        recorder = JsonlRecorder(Path("outputs")/"failures", "failed_items")
-        recorder.record(data, infos={"reason": "..."})
-    """
-
-    def __init__(self, root_dir: Path, prefix: str):
-        self.root_dir = Path(root_dir)
-        self.prefix = prefix
-        self.writer = DailyJsonlWriter(self.root_dir)
-
-    def record(
-        self, data: dict, infos: dict | None = None, subdir: Path | None = None
-    ) -> Path:
-        payload = DailyJsonlWriter.wrap_with_infos(data, infos) if infos else data
-        return self.writer.write(self.prefix, payload, subdir=subdir)
+from piddiplatsch.persist.helpers import DailyJsonlWriter
 
 
 class RecorderBase(ABC):
@@ -128,39 +77,3 @@ class RecorderBase(ABC):
 
         logging.log(level, f"{kind}: recorded {key} to {path}{suffix}")
         return path
-
-
-def read_jsonl(file_path: Path) -> list[dict]:
-    """Read a JSONL file and return list of dicts. Returns empty list if missing."""
-    if not file_path.exists():
-        return []
-    records: list[dict] = []
-    with file_path.open("r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                records.append(json.loads(line))
-            except Exception:
-                # Skip malformed lines but keep going
-                continue
-    return records
-
-
-def find_jsonl(paths: Iterable[Path]) -> list[Path]:
-    """Resolve a sequence of files/dirs/globs to a sorted unique list of JSONL file paths."""
-    files: set[Path] = set()
-    for path in paths:
-        if path.is_file():
-            if path.suffix == ".jsonl":
-                files.add(path)
-        elif path.is_dir():
-            files.update(p for p in path.glob("*.jsonl") if p.is_file())
-        else:
-            parent = path.parent
-            pattern = path.name
-            files.update(
-                p for p in parent.glob(pattern) if p.is_file() and p.suffix == ".jsonl"
-            )
-    return sorted(files)

--- a/src/piddiplatsch/persist/base.py
+++ b/src/piddiplatsch/persist/base.py
@@ -1,7 +1,7 @@
 import json
+from collections.abc import Iterable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Iterable
 
 
 class DailyJsonlWriter:
@@ -47,7 +47,9 @@ class JsonlRecorder:
         self.prefix = prefix
         self.writer = DailyJsonlWriter(self.root_dir)
 
-    def record(self, data: dict, infos: dict | None = None, subdir: Path | None = None) -> Path:
+    def record(
+        self, data: dict, infos: dict | None = None, subdir: Path | None = None
+    ) -> Path:
         payload = DailyJsonlWriter.wrap_with_infos(data, infos) if infos else data
         return self.writer.write(self.prefix, payload, subdir=subdir)
 

--- a/src/piddiplatsch/persist/base.py
+++ b/src/piddiplatsch/persist/base.py
@@ -2,7 +2,10 @@ import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
 
-from piddiplatsch.persist.helpers import DailyJsonlWriter
+from piddiplatsch.persist.helpers import (
+    DailyJsonlWriter,
+    PrepareResult,
+)
 
 
 class RecorderBase(ABC):
@@ -29,7 +32,7 @@ class RecorderBase(ABC):
         data: dict,
         reason: str | None,
         retries: int | None,
-    ) -> tuple[dict, dict | None, Path | None]:
+    ) -> PrepareResult:
         """Return a tuple of (payload, infos, subdir).
 
         - `payload`: dict to be written (before infos wrapping)
@@ -46,7 +49,8 @@ class RecorderBase(ABC):
         reason: str | None = None,
         retries: int | None = None,
     ) -> Path:
-        payload, infos, subdir = self.prepare(key, data, reason, retries)
+        result = self.prepare(key, data, reason, retries)
+        payload, infos, subdir = result.payload, result.infos, result.subdir
         if infos:
             payload = DailyJsonlWriter.wrap_with_infos(payload, infos)
         return self.writer.write(self.prefix, payload, subdir=subdir)

--- a/src/piddiplatsch/persist/base.py
+++ b/src/piddiplatsch/persist/base.py
@@ -1,0 +1,33 @@
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+class DailyJsonlWriter:
+    """Utility for writing JSONL records to daily-rotated files.
+
+    - Uses a directory (root) and a filename prefix (e.g., 'skipped_items').
+    - Appends one JSON object per line.
+    - Returns the path of the written file.
+    """
+
+    def __init__(self, root_dir: Path):
+        self.root_dir = Path(root_dir)
+        self.root_dir.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def wrap_with_infos(data: dict, infos: dict) -> dict:
+        # Merge metadata under `__infos__` key
+        wrapped = {**data, "__infos__": infos}
+        return wrapped
+
+    def write(self, prefix: str, data: dict, subdir: Path | None = None) -> Path:
+        now = datetime.now(UTC)
+        dated_filename = f"{prefix}_{now.date()}.jsonl"
+        target_dir = Path(subdir) if subdir else self.root_dir
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_path = target_dir / dated_filename
+        with target_path.open("a", encoding="utf-8") as f:
+            json.dump(data, f)
+            f.write("\n")
+        return target_path

--- a/src/piddiplatsch/persist/dump.py
+++ b/src/piddiplatsch/persist/dump.py
@@ -6,6 +6,8 @@ from piddiplatsch.persist.base import RecorderBase
 
 
 class DumpRecorder(RecorderBase):
+    LOG_KIND = "dump"
+    LOG_LEVEL = logging.DEBUG
     DUMP_DIR = Path(config.get("consumer", {}).get("output_dir", "outputs")) / "dump"
     DUMP_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -21,10 +23,3 @@ class DumpRecorder(RecorderBase):
     ) -> tuple[dict, dict | None, Path | None]:
         # No infos, just write raw payload
         return data, None, None
-
-    @staticmethod
-    def record(
-        key: str, data: dict, *, reason: str | None = None, retries: int | None = None
-    ) -> None:
-        path = DumpRecorder().write(key, data, reason=reason, retries=retries)
-        logging.debug(f"Dumped message {key} to {path}")

--- a/src/piddiplatsch/persist/dump.py
+++ b/src/piddiplatsch/persist/dump.py
@@ -2,16 +2,29 @@ import logging
 from pathlib import Path
 
 from piddiplatsch.config import config
-from piddiplatsch.persist.base import JsonlRecorder
+from piddiplatsch.persist.base import RecorderBase
 
 
-class DumpRecorder:
+class DumpRecorder(RecorderBase):
     DUMP_DIR = Path(config.get("consumer", {}).get("output_dir", "outputs")) / "dump"
     DUMP_DIR.mkdir(parents=True, exist_ok=True)
 
+    def __init__(self) -> None:
+        super().__init__(self.DUMP_DIR, "dump_messages")
+
+    def prepare(
+        self,
+        key: str,
+        data: dict,
+        reason: str | None,
+        retries: int | None,
+    ) -> tuple[dict, dict | None, Path | None]:
+        # No infos, just write raw payload
+        return data, None, None
+
     @staticmethod
-    def record_item(key: str, data: dict) -> None:
-        # Write raw message as-is, one JSON per line
-        recorder = JsonlRecorder(DumpRecorder.DUMP_DIR, "dump_messages")
-        path = recorder.record(data)
+    def record(
+        key: str, data: dict, *, reason: str | None = None, retries: int | None = None
+    ) -> None:
+        path = DumpRecorder().write(key, data, reason=reason, retries=retries)
         logging.debug(f"Dumped message {key} to {path}")

--- a/src/piddiplatsch/persist/dump.py
+++ b/src/piddiplatsch/persist/dump.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from piddiplatsch.config import config
 from piddiplatsch.persist.base import RecorderBase
+from piddiplatsch.persist.helpers import PrepareResult
 
 
 class DumpRecorder(RecorderBase):
@@ -20,6 +21,6 @@ class DumpRecorder(RecorderBase):
         data: dict,
         reason: str | None,
         retries: int | None,
-    ) -> tuple[dict, dict | None, Path | None]:
+    ) -> PrepareResult:
         # No infos, just write raw payload
-        return data, None, None
+        return PrepareResult(payload=data)

--- a/src/piddiplatsch/persist/dump.py
+++ b/src/piddiplatsch/persist/dump.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 
 from piddiplatsch.config import config
-from piddiplatsch.persist.base import DailyJsonlWriter
+from piddiplatsch.persist.base import JsonlRecorder
 
 
 class DumpRecorder:
@@ -12,6 +12,6 @@ class DumpRecorder:
     @staticmethod
     def record_item(key: str, data: dict) -> None:
         # Write raw message as-is, one JSON per line
-        writer = DailyJsonlWriter(DumpRecorder.DUMP_DIR)
-        path = writer.write("dump_messages", data)
+        recorder = JsonlRecorder(DumpRecorder.DUMP_DIR, "dump_messages")
+        path = recorder.record(data)
         logging.debug(f"Dumped message {key} to {path}")

--- a/src/piddiplatsch/persist/dump.py
+++ b/src/piddiplatsch/persist/dump.py
@@ -1,9 +1,8 @@
-import json
 import logging
-from datetime import UTC, datetime
 from pathlib import Path
 
 from piddiplatsch.config import config
+from piddiplatsch.persist.base import DailyJsonlWriter
 
 
 class DumpRecorder:
@@ -12,13 +11,7 @@ class DumpRecorder:
 
     @staticmethod
     def record_item(key: str, data: dict) -> None:
-        now = datetime.now(UTC)
-        dated_filename = f"dump_messages_{now.date()}.jsonl"
-        dump_file = DumpRecorder.DUMP_DIR / dated_filename
-        # record = {"key": key, "value": data, "timestamp": now.isoformat()}
-        record = data
-        with dump_file.open("a", encoding="utf-8") as f:
-            json.dump(record, f)
-            f.write("\n")
-
-        logging.debug(f"Dumped message {key} to {dump_file}")
+        # Write raw message as-is, one JSON per line
+        writer = DailyJsonlWriter(DumpRecorder.DUMP_DIR)
+        path = writer.write("dump_messages", data)
+        logging.debug(f"Dumped message {key} to {path}")

--- a/src/piddiplatsch/persist/helpers.py
+++ b/src/piddiplatsch/persist/helpers.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -32,6 +33,13 @@ class DailyJsonlWriter:
             json.dump(data, f)
             f.write("\n")
         return target_path
+
+
+@dataclass
+class PrepareResult:
+    payload: dict
+    infos: dict | None = None
+    subdir: Path | None = None
 
 
 def read_jsonl(file_path: Path) -> list[dict]:

--- a/src/piddiplatsch/persist/helpers.py
+++ b/src/piddiplatsch/persist/helpers.py
@@ -1,0 +1,70 @@
+import json
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+class DailyJsonlWriter:
+    """Utility for writing JSONL records to daily-rotated files.
+
+    - Uses a directory (root) and a filename prefix (e.g., 'skipped_items').
+    - Appends one JSON object per line.
+    - Returns the path of the written file.
+    """
+
+    def __init__(self, root_dir: Path):
+        self.root_dir = Path(root_dir)
+        self.root_dir.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def wrap_with_infos(data: dict, infos: dict) -> dict:
+        # Merge metadata under `__infos__` key
+        wrapped = {**data, "__infos__": infos}
+        return wrapped
+
+    def write(self, prefix: str, data: dict, subdir: Path | None = None) -> Path:
+        now = datetime.now(UTC)
+        dated_filename = f"{prefix}_{now.date()}.jsonl"
+        target_dir = Path(subdir) if subdir else self.root_dir
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_path = target_dir / dated_filename
+        with target_path.open("a", encoding="utf-8") as f:
+            json.dump(data, f)
+            f.write("\n")
+        return target_path
+
+
+def read_jsonl(file_path: Path) -> list[dict]:
+    """Read a JSONL file and return list of dicts. Returns empty list if missing."""
+    if not file_path.exists():
+        return []
+    records: list[dict] = []
+    with file_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except Exception:
+                # Skip malformed lines but keep going
+                continue
+    return records
+
+
+def find_jsonl(paths: Iterable[Path]) -> list[Path]:
+    """Resolve a sequence of files/dirs/globs to a sorted unique list of JSONL file paths."""
+    files: set[Path] = set()
+    for path in paths:
+        if path.is_file():
+            if path.suffix == ".jsonl":
+                files.add(path)
+        elif path.is_dir():
+            files.update(p for p in path.glob("*.jsonl") if p.is_file())
+        else:
+            parent = path.parent
+            pattern = path.name
+            files.update(
+                p for p in parent.glob(pattern) if p.is_file() and p.suffix == ".jsonl"
+            )
+    return sorted(files)

--- a/src/piddiplatsch/persist/recovery.py
+++ b/src/piddiplatsch/persist/recovery.py
@@ -12,6 +12,8 @@ from piddiplatsch.processing import RetryResult
 
 
 class FailureRecovery(RecorderBase):
+    LOG_KIND = "failure"
+    LOG_LEVEL = logging.WARNING
     FAILURE_DIR = (
         Path(config.get("consumer", {}).get("output_dir", "outputs")) / "failures"
     )
@@ -32,15 +34,6 @@ class FailureRecovery(RecorderBase):
         infos = {"failure_timestamp": ts, "retries": r, "reason": reason or "Unknown"}
         subdir = self.root_dir / f"r{r}"
         return data, infos, subdir
-
-    @staticmethod
-    def record(
-        key: str, data: dict, *, reason: str | None = None, retries: int | None = None
-    ) -> None:
-        path = FailureRecovery().write(key, data, reason=reason, retries=retries)
-        logging.warning(
-            f"Recorded failed item {key} (retries={0 if retries is None else retries}) to {path}"
-        )
 
     @staticmethod
     def load_failed_messages(jsonl_path: Path) -> list[tuple[str, dict]]:

--- a/src/piddiplatsch/persist/recovery.py
+++ b/src/piddiplatsch/persist/recovery.py
@@ -1,11 +1,14 @@
-import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
 from piddiplatsch.config import config
+from piddiplatsch.persist.base import (
+    JsonlRecorder,
+    find_jsonl,
+    read_jsonl,
+)
 from piddiplatsch.processing import RetryResult
-from piddiplatsch.persist.base import DailyJsonlWriter, read_jsonl, find_jsonl, JsonlRecorder
 
 
 class FailureRecovery:
@@ -28,9 +31,7 @@ class FailureRecovery:
         retry_folder = FailureRecovery.FAILURE_DIR / f"r{retries}"
         recorder = JsonlRecorder(retry_folder, "failed_items")
         path = recorder.record(data, infos=infos)
-        logging.warning(
-            f"Recorded failed item {key} (retries={retries}) to {path}"
-        )
+        logging.warning(f"Recorded failed item {key} (retries={retries}) to {path}")
 
     @staticmethod
     def load_failed_messages(jsonl_path: Path) -> list[tuple[str, dict]]:

--- a/src/piddiplatsch/persist/recovery.py
+++ b/src/piddiplatsch/persist/recovery.py
@@ -3,11 +3,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from piddiplatsch.config import config
-from piddiplatsch.persist.base import (
-    RecorderBase,
-    find_jsonl,
-    read_jsonl,
-)
+from piddiplatsch.persist.base import RecorderBase
+from piddiplatsch.persist.helpers import find_jsonl, read_jsonl
 from piddiplatsch.processing import RetryResult
 
 

--- a/src/piddiplatsch/persist/recovery.py
+++ b/src/piddiplatsch/persist/recovery.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from piddiplatsch.config import config
 from piddiplatsch.persist.base import RecorderBase
-from piddiplatsch.persist.helpers import find_jsonl, read_jsonl
+from piddiplatsch.persist.helpers import PrepareResult, find_jsonl, read_jsonl
 from piddiplatsch.processing import RetryResult
 
 
@@ -25,12 +25,12 @@ class FailureRecovery(RecorderBase):
         data: dict,
         reason: str | None,
         retries: int | None,
-    ) -> tuple[dict, dict | None, Path | None]:
+    ) -> PrepareResult:
         ts = datetime.now(UTC).isoformat(timespec="seconds")
         r = 0 if retries is None else int(retries)
         infos = {"failure_timestamp": ts, "retries": r, "reason": reason or "Unknown"}
         subdir = self.root_dir / f"r{r}"
-        return data, infos, subdir
+        return PrepareResult(payload=data, infos=infos, subdir=subdir)
 
     @staticmethod
     def load_failed_messages(jsonl_path: Path) -> list[tuple[str, dict]]:

--- a/src/piddiplatsch/persist/skipped.py
+++ b/src/piddiplatsch/persist/skipped.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from piddiplatsch.config import config
 from piddiplatsch.persist.base import RecorderBase
+from piddiplatsch.persist.helpers import PrepareResult
 
 
 class SkipRecorder(RecorderBase):
@@ -22,7 +23,7 @@ class SkipRecorder(RecorderBase):
         data: dict,
         reason: str | None,
         retries: int | None,
-    ) -> tuple[dict, dict | None, Path | None]:
+    ) -> PrepareResult:
         timestamp = datetime.now(UTC).isoformat(timespec="seconds")
         payload = dict(data)
         # Determine retries value: explicit overrides payload value
@@ -45,4 +46,4 @@ class SkipRecorder(RecorderBase):
             "retries": int(payload_retries or 0),
             "reason": reason or "Unknown",
         }
-        return payload, infos, None
+        return PrepareResult(payload=payload, infos=infos, subdir=None)

--- a/src/piddiplatsch/persist/skipped.py
+++ b/src/piddiplatsch/persist/skipped.py
@@ -1,45 +1,29 @@
-import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
 from piddiplatsch.config import config
+from piddiplatsch.persist.base import DailyJsonlWriter
 
 
 class SkipRecorder:
     SKIPPED_DIR = (
         Path(config.get("consumer", {}).get("output_dir", "outputs")) / "skipped"
     )
-    SKIPPED_DIR.mkdir(parents=True, exist_ok=True)
 
     @staticmethod
     def record_skipped_item(key: str, data: dict, reason: str | None = None) -> None:
-        """Append a skipped item to a daily JSONL file with UTC timestamp.
-
-        Records minimal metadata under `__infos__` including timestamp, reason, and retries counter.
-        """
-        now = datetime.now(UTC)
-        timestamp = now.isoformat(timespec="seconds")
-        dated_filename = f"skipped_items_{now.date()}.jsonl"
-
-        skipped_file = SkipRecorder.SKIPPED_DIR / dated_filename
-
+        """Append a skipped item to daily JSONL with timestamp and reason."""
+        timestamp = datetime.now(UTC).isoformat(timespec="seconds")
         infos = {
             "skip_timestamp": timestamp,
             "retries": int(data.get("retries", 0)),
             "reason": reason or "Unknown",
         }
-
-        # Store original data with metadata for later retry
-        data_with_metadata = {
-            **data,
-            "__infos__": infos,
-        }
-
+        payload = DailyJsonlWriter.wrap_with_infos(data, infos)
         try:
-            with skipped_file.open("a", encoding="utf-8") as f:
-                json.dump(data_with_metadata, f)
-                f.write("\n")
-            logging.warning(f"Recorded skipped item {key} to {skipped_file}")
+            writer = DailyJsonlWriter(SkipRecorder.SKIPPED_DIR)
+            path = writer.write("skipped_items", payload)
+            logging.warning(f"Recorded skipped item {key} to {path}")
         except Exception:
-            logging.exception(f"Failed to record skipped item {key} to {skipped_file}")
+            logging.exception(f"Failed to record skipped item {key}")

--- a/src/piddiplatsch/persist/skipped.py
+++ b/src/piddiplatsch/persist/skipped.py
@@ -3,26 +3,54 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from piddiplatsch.config import config
-from piddiplatsch.persist.base import JsonlRecorder
+from piddiplatsch.persist.base import RecorderBase
 
 
-class SkipRecorder:
+class SkipRecorder(RecorderBase):
     SKIPPED_DIR = (
         Path(config.get("consumer", {}).get("output_dir", "outputs")) / "skipped"
     )
 
-    @staticmethod
-    def record_skipped_item(key: str, data: dict, reason: str | None = None) -> None:
-        """Append a skipped item to daily JSONL with timestamp and reason."""
+    def __init__(self) -> None:
+        super().__init__(self.SKIPPED_DIR, "skipped_items")
+
+    def prepare(
+        self,
+        key: str,
+        data: dict,
+        reason: str | None,
+        retries: int | None,
+    ) -> tuple[dict, dict | None, Path | None]:
         timestamp = datetime.now(UTC).isoformat(timespec="seconds")
+        payload = dict(data)
+        # Determine retries value: explicit overrides payload value
+        payload_retries = retries
+        if payload_retries is None:
+            payload_retries = int(
+                (payload.get("__infos__", {}) or {}).get(
+                    "retries", payload.get("retries", 0)
+                )
+            )
+        else:
+            # reflect retries in payload for loader semantics
+            if "__infos__" in payload:
+                payload["__infos__"]["retries"] = payload_retries
+            else:
+                payload["retries"] = payload_retries
+
         infos = {
             "skip_timestamp": timestamp,
-            "retries": int(data.get("retries", 0)),
+            "retries": int(payload_retries or 0),
             "reason": reason or "Unknown",
         }
+        return payload, infos, None
+
+    @staticmethod
+    def record(
+        key: str, data: dict, *, reason: str | None = None, retries: int | None = None
+    ) -> None:
         try:
-            recorder = JsonlRecorder(SkipRecorder.SKIPPED_DIR, "skipped_items")
-            path = recorder.record(data, infos=infos)
+            path = SkipRecorder().write(key, data, reason=reason, retries=retries)
             logging.warning(f"Recorded skipped item {key} to {path}")
         except Exception:
             logging.exception(f"Failed to record skipped item {key}")

--- a/src/piddiplatsch/persist/skipped.py
+++ b/src/piddiplatsch/persist/skipped.py
@@ -1,0 +1,45 @@
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from piddiplatsch.config import config
+
+
+class SkipRecorder:
+    SKIPPED_DIR = (
+        Path(config.get("consumer", {}).get("output_dir", "outputs")) / "skipped"
+    )
+    SKIPPED_DIR.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def record_skipped_item(key: str, data: dict, reason: str | None = None) -> None:
+        """Append a skipped item to a daily JSONL file with UTC timestamp.
+
+        Records minimal metadata under `__infos__` including timestamp, reason, and retries counter.
+        """
+        now = datetime.now(UTC)
+        timestamp = now.isoformat(timespec="seconds")
+        dated_filename = f"skipped_items_{now.date()}.jsonl"
+
+        skipped_file = SkipRecorder.SKIPPED_DIR / dated_filename
+
+        infos = {
+            "skip_timestamp": timestamp,
+            "retries": int(data.get("retries", 0)),
+            "reason": reason or "Unknown",
+        }
+
+        # Store original data with metadata for later retry
+        data_with_metadata = {
+            **data,
+            "__infos__": infos,
+        }
+
+        try:
+            with skipped_file.open("a", encoding="utf-8") as f:
+                json.dump(data_with_metadata, f)
+                f.write("\n")
+            logging.warning(f"Recorded skipped item {key} to {skipped_file}")
+        except Exception:
+            logging.exception(f"Failed to record skipped item {key} to {skipped_file}")

--- a/src/piddiplatsch/persist/skipped.py
+++ b/src/piddiplatsch/persist/skipped.py
@@ -7,6 +7,8 @@ from piddiplatsch.persist.base import RecorderBase
 
 
 class SkipRecorder(RecorderBase):
+    LOG_KIND = "skipped"
+    LOG_LEVEL = logging.WARNING
     SKIPPED_DIR = (
         Path(config.get("consumer", {}).get("output_dir", "outputs")) / "skipped"
     )
@@ -44,13 +46,3 @@ class SkipRecorder(RecorderBase):
             "reason": reason or "Unknown",
         }
         return payload, infos, None
-
-    @staticmethod
-    def record(
-        key: str, data: dict, *, reason: str | None = None, retries: int | None = None
-    ) -> None:
-        try:
-            path = SkipRecorder().write(key, data, reason=reason, retries=retries)
-            logging.warning(f"Recorded skipped item {key} to {path}")
-        except Exception:
-            logging.exception(f"Failed to record skipped item {key}")

--- a/src/piddiplatsch/persist/skipped.py
+++ b/src/piddiplatsch/persist/skipped.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from piddiplatsch.config import config
-from piddiplatsch.persist.base import DailyJsonlWriter
+from piddiplatsch.persist.base import JsonlRecorder
 
 
 class SkipRecorder:
@@ -20,10 +20,9 @@ class SkipRecorder:
             "retries": int(data.get("retries", 0)),
             "reason": reason or "Unknown",
         }
-        payload = DailyJsonlWriter.wrap_with_infos(data, infos)
         try:
-            writer = DailyJsonlWriter(SkipRecorder.SKIPPED_DIR)
-            path = writer.write("skipped_items", payload)
+            recorder = JsonlRecorder(SkipRecorder.SKIPPED_DIR, "skipped_items")
+            path = recorder.record(data, infos=infos)
             logging.warning(f"Recorded skipped item {key} to {path}")
         except Exception:
             logging.exception(f"Failed to record skipped item {key}")

--- a/src/piddiplatsch/processing/cmip6_processor.py
+++ b/src/piddiplatsch/processing/cmip6_processor.py
@@ -3,9 +3,12 @@ from typing import Any
 
 import jsonpatch
 from pydantic import ValidationError
+import requests
+import time
 
 from piddiplatsch.config import config
 from piddiplatsch.processing import BaseProcessor, ProcessingResult
+from piddiplatsch.exceptions import TransientExternalError
 from piddiplatsch.records import CMIP6DatasetRecord
 from piddiplatsch.records.cmip6_file_record import extract_asset_records
 from piddiplatsch.utils.stac import get_stac_client
@@ -22,6 +25,29 @@ class CMIP6Processor(BaseProcessor):
             "excluded_asset_keys", self.EXCLUDED_ASSET_KEYS
         )
         self.stac_client = get_stac_client()
+
+    def preflight_check(self, stop_on_transient_skip: bool = True):
+        """Optionally check STAC availability before consuming.
+
+        If remote STAC is configured and unreachable, raise TransientExternalError
+        when policy dictates fail-fast.
+        """
+        stac_cfg = config.get("stac", {})
+        base_url = stac_cfg.get("base_url")
+        preflight = bool(config.get("consumer", {}).get("preflight_stac", True))
+        timeout = float(stac_cfg.get("timeout", 10.0))
+        if not preflight or not base_url:
+            return
+        try:
+            # lightweight probe
+            url = base_url.rstrip("/") + "/collections?limit=1"
+            resp = requests.get(url, timeout=min(timeout, 3.0))
+            resp.raise_for_status()
+        except Exception as e:
+            if stop_on_transient_skip:
+                raise TransientExternalError(f"STAC preflight failed: {e}")
+            # else, just log and continue in force/dev mode
+            self.logger.warning(f"STAC preflight failed but continuing: {e}")
 
     def process(self, key: str, value: dict[str, Any]) -> ProcessingResult:
         self.logger.debug(f"CMIP6 plugin processing key={key}")
@@ -49,9 +75,7 @@ class CMIP6Processor(BaseProcessor):
         """Check payload presence and delegate to payload processor."""
         payload = value.get("data", {}).get("payload")
         if not payload:
-            self._log_skipped(key, "MISSING payload")
-            result.skipped = True
-            return result
+            raise ValueError("MISSING payload")
 
         metadata = value.get("metadata", {})
         return self._process_payload(payload, metadata, key, result)
@@ -69,16 +93,22 @@ class CMIP6Processor(BaseProcessor):
                 item = self._apply_patch_to_stac_item(payload)
                 self.logger.info(f"Patched item with key={key}.")
                 result.patched = True
+            except TransientExternalError as e:
+                self.logger.error(f"External failure during patch for key={key}: {e}")
+                result.skipped = True
+                result.skip_reason = f"TRANSIENT external: {e}"
+                result.transient_skip = True
+                return result
+            except jsonpatch.JsonPatchException as e:
+                self.logger.error(f"Invalid JSON Patch for key={key}: {e}")
+                raise
             except Exception as e:
                 self.logger.error(f"Failed to apply patch for key={key}: {e}")
-                result.skipped = True
-                return result
+                raise
         elif "item" in payload:
             item = payload["item"]
         else:
-            self._log_skipped(key, "MISSING item")
-            result.skipped = True
-            return result
+            raise ValueError("MISSING item")
 
         # Create record
         additional_attrs = {"publication_time": metadata.get("time")}
@@ -102,21 +132,56 @@ class CMIP6Processor(BaseProcessor):
         return result
 
     def _apply_patch_to_stac_item(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """Fetch the STAC item and apply a JSON patch."""
+        """Fetch the STAC item and apply a JSON patch with retries and backoff.
+
+        Raises TransientExternalError if STAC is unreachable or returns 5xx after retries.
+        Raises JsonPatchException for invalid patch specs.
+        """
         collection_id = payload["collection_id"]
         item_id = payload["item_id"]
         patch_data = payload["patch"]
+        retries = int(config.get("consumer", {}).get("transient_retries", 3))
+        base_delay = float(config.get("consumer", {}).get("transient_backoff_initial", 0.5))
+        max_delay = float(config.get("consumer", {}).get("transient_backoff_max", 5.0))
 
-        item = self.stac_client.get_item(collection_id, item_id)
-        if item is None:
-            raise ValueError(f"STAC item {collection_id}/{item_id} not found")
+        last_err: Exception | None = None
+        delay = base_delay
+        for attempt in range(1, retries + 2):
+            try:
+                item = self.stac_client.get_item(collection_id, item_id)
+                if item is None:
+                    raise requests.HTTPError(f"404 Not Found for {collection_id}/{item_id}")
+                patch_obj = jsonpatch.JsonPatch(patch_data["operations"])
+                patched_item = patch_obj.apply(item)
+                self.logger.info(
+                    f"Applied patch to STAC item {collection_id}/{item_id}"
+                )
+                self.logger.debug(f"patched item: {patched_item}")
+                return patched_item
+            except requests.Timeout as e:
+                last_err = e
+                self.logger.warning(f"Timeout fetching STAC item (attempt {attempt}): {e}")
+            except requests.ConnectionError as e:
+                last_err = e
+                self.logger.warning(f"Connection error fetching STAC item (attempt {attempt}): {e}")
+            except requests.HTTPError as e:
+                last_err = e
+                self.logger.warning(f"HTTP error fetching STAC item (attempt {attempt}): {e}")
+            except jsonpatch.JsonPatchException:
+                # invalid patch is permanent error
+                raise
+            except Exception as e:
+                last_err = e
+                self.logger.warning(f"Unexpected error fetching STAC item (attempt {attempt}): {e}")
 
-        patch_obj = jsonpatch.JsonPatch(patch_data["operations"])
-        patched_item = patch_obj.apply(item)
+            # backoff before next attempt (only for transient/classified errors)
+            if attempt <= retries:
+                time.sleep(delay)
+                delay = min(delay * 2, max_delay)
 
-        self.logger.info(f"Applied patch to STAC item {collection_id}/{item_id}")
-        self.logger.debug(f"patched item: {patched_item}")
-        return patched_item
+        raise TransientExternalError(
+            f"Failed to fetch/apply patch for {collection_id}/{item_id} after {retries + 1} attempts: {last_err}"
+        )
 
     def _add_records_from_item(
         self, record: CMIP6DatasetRecord, item: dict[str, Any]

--- a/src/piddiplatsch/processing/result.py
+++ b/src/piddiplatsch/processing/result.py
@@ -9,6 +9,8 @@ class ProcessingResult:
     success: bool = False
     error: str | None = None
     skipped: bool = False
+    skip_reason: str | None = None
+    transient_skip: bool = False
     patched: bool = False
     elapsed: float = 0.0
 

--- a/tests/test_persist_dump.py
+++ b/tests/test_persist_dump.py
@@ -24,7 +24,7 @@ def test_record_single_item(temp_dump_dir):
     key = "testkey"
     data = {"foo": "bar"}
 
-    DumpRecorder.record(key, data)
+    DumpRecorder().record(key, data)
 
     files = list(temp_dump_dir.glob("*.jsonl"))
     assert len(files) == 1
@@ -45,7 +45,7 @@ def test_record_multiple_items_append(temp_dump_dir):
     ]
 
     for key, data in records:
-        DumpRecorder.record(key, data)
+        DumpRecorder().record(key, data)
 
     files = list(temp_dump_dir.glob("*.jsonl"))
     assert len(files) == 1
@@ -64,7 +64,7 @@ def test_dump_filename_contains_today(temp_dump_dir):
     key = "datekey"
     data = {"hello": "world"}
 
-    DumpRecorder.record(key, data)
+    DumpRecorder().record(key, data)
 
     files = list(temp_dump_dir.glob("*.jsonl"))
     assert len(files) == 1

--- a/tests/test_persist_dump.py
+++ b/tests/test_persist_dump.py
@@ -24,7 +24,7 @@ def test_record_single_item(temp_dump_dir):
     key = "testkey"
     data = {"foo": "bar"}
 
-    DumpRecorder.record_item(key, data)
+    DumpRecorder.record(key, data)
 
     files = list(temp_dump_dir.glob("*.jsonl"))
     assert len(files) == 1
@@ -45,7 +45,7 @@ def test_record_multiple_items_append(temp_dump_dir):
     ]
 
     for key, data in records:
-        DumpRecorder.record_item(key, data)
+        DumpRecorder.record(key, data)
 
     files = list(temp_dump_dir.glob("*.jsonl"))
     assert len(files) == 1
@@ -64,7 +64,7 @@ def test_dump_filename_contains_today(temp_dump_dir):
     key = "datekey"
     data = {"hello": "world"}
 
-    DumpRecorder.record_item(key, data)
+    DumpRecorder.record(key, data)
 
     files = list(temp_dump_dir.glob("*.jsonl"))
     assert len(files) == 1

--- a/tests/test_persist_skipped.py
+++ b/tests/test_persist_skipped.py
@@ -1,0 +1,54 @@
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from piddiplatsch.persist.skipped import SkipRecorder
+
+
+@pytest.fixture
+def temp_skipped_dir(tmp_path, monkeypatch):
+    """
+    Provide a temporary skipped directory and patch SkipRecorder.SKIPPED_DIR.
+    Ensures tests do not affect the real filesystem.
+    """
+    skipped_dir = tmp_path / "skipped"
+    skipped_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(SkipRecorder, "SKIPPED_DIR", skipped_dir)
+    return skipped_dir
+
+
+def test_record_single_skipped_item(temp_skipped_dir):
+    key = "testkey"
+    data = {"foo": "bar"}
+
+    SkipRecorder.record_skipped_item(key, data, reason="network failure")
+
+    files = list(temp_skipped_dir.glob("*.jsonl"))
+    assert len(files) == 1
+
+    with files[0].open("r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    assert len(lines) == 1
+    obj = json.loads(lines[0])
+    assert obj["foo"] == "bar"
+    assert "__infos__" in obj
+    assert obj["__infos__"]["reason"] == "network failure"
+    assert isinstance(obj["__infos__"]["retries"], int)
+
+
+def test_skipped_filename_contains_today(temp_skipped_dir):
+    key = "datekey"
+    data = {"hello": "world"}
+
+    SkipRecorder.record_skipped_item(key, data, reason="timeout")
+
+    files = list(temp_skipped_dir.glob("*.jsonl"))
+    assert len(files) == 1
+
+    today = datetime.now(UTC).date()
+    expected_filename = f"skipped_items_{today}.jsonl"
+    actual_filename = files[0].name
+
+    assert actual_filename == expected_filename

--- a/tests/test_persist_skipped.py
+++ b/tests/test_persist_skipped.py
@@ -22,7 +22,7 @@ def test_record_single_skipped_item(temp_skipped_dir):
     key = "testkey"
     data = {"foo": "bar"}
 
-    SkipRecorder.record_skipped_item(key, data, reason="network failure")
+    SkipRecorder.record(key, data, reason="network failure")
 
     files = list(temp_skipped_dir.glob("*.jsonl"))
     assert len(files) == 1
@@ -42,7 +42,7 @@ def test_skipped_filename_contains_today(temp_skipped_dir):
     key = "datekey"
     data = {"hello": "world"}
 
-    SkipRecorder.record_skipped_item(key, data, reason="timeout")
+    SkipRecorder.record(key, data, reason="timeout")
 
     files = list(temp_skipped_dir.glob("*.jsonl"))
     assert len(files) == 1

--- a/tests/test_persist_skipped.py
+++ b/tests/test_persist_skipped.py
@@ -22,7 +22,7 @@ def test_record_single_skipped_item(temp_skipped_dir):
     key = "testkey"
     data = {"foo": "bar"}
 
-    SkipRecorder.record(key, data, reason="network failure")
+    SkipRecorder().record(key, data, reason="network failure")
 
     files = list(temp_skipped_dir.glob("*.jsonl"))
     assert len(files) == 1
@@ -42,7 +42,7 @@ def test_skipped_filename_contains_today(temp_skipped_dir):
     key = "datekey"
     data = {"hello": "world"}
 
-    SkipRecorder.record(key, data, reason="timeout")
+    SkipRecorder().record(key, data, reason="timeout")
 
     files = list(temp_skipped_dir.glob("*.jsonl"))
     assert len(files) == 1

--- a/tests/test_retry_skipped.py
+++ b/tests/test_retry_skipped.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+from piddiplatsch.persist.recovery import FailureRecovery
+
+
+def test_retry_on_skipped_jsonl(tmp_path):
+    # Prepare a skipped JSONL file with a valid item payload
+    f = tmp_path / "skipped_items.jsonl"
+    record = {
+        "data": {
+            "payload": {
+                "item": {
+                    "id": "cmip6.foo.bar.baz.exp.r1i1p1f1.table.var.grid.v20200101",
+                    "type": "Feature",
+                    "collection": "cmip6",
+                    "properties": {},
+                    "links": [],
+                    "assets": {},
+                }
+            }
+        },
+        "metadata": {"time": "2024-01-01T00:00:00Z"},
+    }
+    f.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+    result = FailureRecovery.retry(
+        f,
+        processor="cmip6",
+        delete_after=False,
+        dry_run=True,
+    )
+
+    # It should attempt to process the single message
+    assert result.total == 1

--- a/tests/test_retry_skipped.py
+++ b/tests/test_retry_skipped.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 from piddiplatsch.persist.recovery import FailureRecovery
 

--- a/tests/test_skip_flow.py
+++ b/tests/test_skip_flow.py
@@ -1,12 +1,9 @@
 import json
-from pathlib import Path
-
-import pytest
 
 from piddiplatsch.consumer import ConsumerPipeline, DirectConsumer
-from piddiplatsch.processing.cmip6_processor import CMIP6Processor
-from piddiplatsch.persist.skipped import SkipRecorder
 from piddiplatsch.exceptions import TransientExternalError
+from piddiplatsch.persist.skipped import SkipRecorder
+from piddiplatsch.processing.cmip6_processor import CMIP6Processor
 
 
 class FailingPatchProcessor(CMIP6Processor):

--- a/tests/test_skip_flow.py
+++ b/tests/test_skip_flow.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from piddiplatsch.consumer import ConsumerPipeline, DirectConsumer
+from piddiplatsch.processing.cmip6_processor import CMIP6Processor
+from piddiplatsch.persist.skipped import SkipRecorder
+from piddiplatsch.exceptions import TransientExternalError
+
+
+class FailingPatchProcessor(CMIP6Processor):
+    def _apply_patch_to_stac_item(self, payload):
+        raise TransientExternalError("simulated network failure")
+
+
+def test_pipeline_records_skipped_on_patch_failure(tmp_path, monkeypatch):
+    # Patch SkipRecorder directory
+    skipped_dir = tmp_path / "skipped"
+    skipped_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(SkipRecorder, "SKIPPED_DIR", skipped_dir)
+
+    # Construct a PATCH payload that will trigger failure
+    key = "k1"
+    value = {
+        "data": {
+            "payload": {
+                "method": "PATCH",
+                "collection_id": "c1",
+                "item_id": "i1",
+                "patch": {"operations": []},
+            }
+        },
+        "metadata": {"time": "2024-01-01T00:00:00Z"},
+    }
+
+    consumer = DirectConsumer([(key, value)])
+    pipeline = ConsumerPipeline(
+        consumer, processor=FailingPatchProcessor(dry_run=True), force=True
+    )
+
+    pipeline.run()
+
+    # Verify skipped file written
+    files = list(skipped_dir.glob("*.jsonl"))
+    assert len(files) == 1
+    content = files[0].read_text(encoding="utf-8").strip().splitlines()
+    assert len(content) == 1
+    obj = json.loads(content[0])
+    assert obj["__infos__"]["reason"].startswith("TRANSIENT external")

--- a/tests/test_transient_stop.py
+++ b/tests/test_transient_stop.py
@@ -1,0 +1,37 @@
+import json
+import pytest
+
+from piddiplatsch.consumer import ConsumerPipeline, DirectConsumer
+from piddiplatsch.processing.cmip6_processor import CMIP6Processor
+from piddiplatsch.exceptions import StopOnTransientSkipError, TransientExternalError
+
+
+class AlwaysTransientProcessor(CMIP6Processor):
+    def _apply_patch_to_stac_item(self, payload):
+        # Simulate external failure after retries
+        raise TransientExternalError("simulated STAC outage")
+
+
+def test_stop_on_transient_skip(monkeypatch):
+    key = "k1"
+    value = {
+        "data": {
+            "payload": {
+                "method": "PATCH",
+                "collection_id": "c1",
+                "item_id": "i1",
+                "patch": {"operations": []},
+            }
+        },
+        "metadata": {"time": "2024-01-01T00:00:00Z"},
+    }
+
+    consumer = DirectConsumer([(key, value)])
+    pipeline = ConsumerPipeline(
+        consumer,
+        processor=AlwaysTransientProcessor(dry_run=True),
+        force=False,
+    )
+
+    with pytest.raises(StopOnTransientSkipError):
+        pipeline.run()

--- a/tests/test_transient_stop.py
+++ b/tests/test_transient_stop.py
@@ -1,9 +1,8 @@
-import json
 import pytest
 
 from piddiplatsch.consumer import ConsumerPipeline, DirectConsumer
-from piddiplatsch.processing.cmip6_processor import CMIP6Processor
 from piddiplatsch.exceptions import StopOnTransientSkipError, TransientExternalError
+from piddiplatsch.processing.cmip6_processor import CMIP6Processor
 
 
 class AlwaysTransientProcessor(CMIP6Processor):


### PR DESCRIPTION
The PR refactors the handling of messages: warn, error, skip. 

It also introduces a `--force` option to proceed with message reading though there are errors.

The `persit` package has been re-written and uses now a common `RecorderBase` class.